### PR TITLE
Fix e2e QueryRef from XR status

### DIFF
--- a/example/queryref-from-xr-status/Makefile
+++ b/example/queryref-from-xr-status/Makefile
@@ -1,3 +1,3 @@
 .PHONY: render
 render:
-	crossplane render ./xr.yaml composition.yaml ../functions.yaml --function-credentials=../secrets/azure-creds.yaml  -rc
+	crossplane render ./xr.yaml composition.yaml ./functions.yaml --function-credentials=../secrets/azure-creds.yaml  -rc

--- a/example/queryref-from-xr-status/composition.yaml
+++ b/example/queryref-from-xr-status/composition.yaml
@@ -20,7 +20,7 @@ spec:
             apiVersion: example.crossplane.io/v1
             kind: XR
             status:
-              azResourceGraphQuery: Resources | where type == "${{ .observed.composite.resource.spec.queryResourceType }}" | count
+              azResourceGraphQuery: Resources | where type == "{{ .observed.composite.resource.spec.queryResourceType }}" | count
     - step: query-azresourcegraph
       functionRef:
         name: function-azresourcegraph
@@ -28,7 +28,7 @@ spec:
         apiVersion: azresourcegraph.fn.crossplane.io/v1alpha1
         kind: Input
         queryRef: "status.azResourceGraphQuery"
-        target: "context.azResourceGraphQueryResult"
+        target: "status.azResourceGraphQueryResult"
       credentials:
         - name: azure-creds
           source: Secret

--- a/example/queryref-from-xr-status/composition.yaml
+++ b/example/queryref-from-xr-status/composition.yaml
@@ -8,17 +8,30 @@ spec:
     kind: XR
   mode: Pipeline
   pipeline:
-  - step: query-azresourcegraph
-    functionRef:
-      name: function-azresourcegraph
-    input:
-      apiVersion: azresourcegraph.fn.crossplane.io/v1alpha1
-      kind: Input
-      queryRef: "status.azResourceGraphQuery"
-      target: "context.azResourceGraphQueryResult"
-    credentials:
-      - name: azure-creds
-        source: Secret
-        secretRef:
-          namespace: upbound-system
-          name: azure-account-creds
+    - step: query-to-status
+      functionRef:
+        name: function-go-templating
+      input:
+        apiVersion: gotemplating.fn.crossplane.io/v1beta1
+        kind: GoTemplate
+        source: Inline
+        inline:
+          template: |
+            apiVersion: example.crossplane.io/v1
+            kind: XR
+            status:
+              azResourceGraphQuery: Resources | where type == "${{ .observed.composite.resource.spec.queryResourceType }}" | count
+    - step: query-azresourcegraph
+      functionRef:
+        name: function-azresourcegraph
+      input:
+        apiVersion: azresourcegraph.fn.crossplane.io/v1alpha1
+        kind: Input
+        queryRef: "status.azResourceGraphQuery"
+        target: "context.azResourceGraphQueryResult"
+      credentials:
+        - name: azure-creds
+          source: Secret
+          secretRef:
+            namespace: upbound-system
+            name: azure-account-creds

--- a/example/queryref-from-xr-status/definition.yaml
+++ b/example/queryref-from-xr-status/definition.yaml
@@ -19,6 +19,10 @@ spec:
           spec:
             description: XRSpec defines the desired state of XR.
             type: object
+            properties:
+              queryResourceType:
+                description: resource type for az resource query construction
+                type: string
           status:
             description: XRStatus defines the observed state of XR.
             type: object
@@ -29,6 +33,9 @@ spec:
                 items:
                   type: object
                 x-kubernetes-preserve-unknown-fields: true
+              azResourceGraphQuery:
+                description: Freeform field containing query results from function-azresourcegraph
+                type: string
         required:
         - spec
         type: object

--- a/example/queryref-from-xr-status/functions.yaml
+++ b/example/queryref-from-xr-status/functions.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-azresourcegraph
+  annotations:
+    # This tells crossplane beta render to connect to the function locally.
+    # render.crossplane.io/runtime: Development
+spec:
+  package: xpkg.upbound.io/upbound/function-azresourcegraph:v0.3.0
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-go-templating
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.9.0

--- a/example/queryref-from-xr-status/functions.yaml
+++ b/example/queryref-from-xr-status/functions.yaml
@@ -7,7 +7,7 @@ metadata:
     # This tells crossplane beta render to connect to the function locally.
     # render.crossplane.io/runtime: Development
 spec:
-  package: xpkg.upbound.io/upbound/function-azresourcegraph:v0.3.0
+  package: xpkg.upbound.io/upbound/function-azresourcegraph:v0.4.0-rc-test
 ---
 apiVersion: pkg.crossplane.io/v1beta1
 kind: Function

--- a/example/queryref-from-xr-status/xr.yaml
+++ b/example/queryref-from-xr-status/xr.yaml
@@ -3,6 +3,7 @@ apiVersion: example.crossplane.io/v1
 kind: XR
 metadata:
   name: example-xr
-spec: {}
+spec:
+  queryResourceType: microsoft.compute/virtualmachines
 status:
   azResourceGraphQuery: Resources| count

--- a/fn.go
+++ b/fn.go
@@ -90,8 +90,8 @@ func (f *Function) RunFunction(ctx context.Context, req *fnv1.RunFunctionRequest
 	}
 
 	if in.Query == "" {
-		response.Fatal(rsp, errors.New("Query is empty"))
-		f.log.Info("FAILURE: ", "query is empty", in.Query)
+		response.Warning(rsp, errors.New("Query is empty"))
+		f.log.Info("WARNING: ", "query is empty", in.Query)
 		return rsp, nil
 	}
 

--- a/fn_test.go
+++ b/fn_test.go
@@ -873,8 +873,8 @@ func TestRunFunction(t *testing.T) {
 				},
 			},
 		},
-		"FailIfQueryIsEmpty": {
-			reason: "The Function should fail if Query is empty",
+		"WarningIfQueryIsEmpty": {
+			reason: "The Function should warn if Query is empty",
 			args: args{
 				ctx: context.Background(),
 				req: &fnv1.RunFunctionRequest{
@@ -909,7 +909,7 @@ func TestRunFunction(t *testing.T) {
 					Meta: &fnv1.ResponseMeta{Tag: "hello", Ttl: durationpb.New(response.DefaultTTL)},
 					Results: []*fnv1.Result{
 						{
-							Severity: fnv1.Severity_SEVERITY_FATAL,
+							Severity: fnv1.Severity_SEVERITY_WARNING,
 							Message:  `Query is empty`,
 							Target:   fnv1.Target_TARGET_COMPOSITE.Enum(),
 						},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

* Do not fatal fail but worn on empty Query
* It will unblock the situation when XR status is getting updated by the
  Function pipeline and the referenced `status.queryField` is available
  only on the consequent reconciliation loop
* Update queryref-from-xr-status example to include
  function-go-templating constructing the query for illustrative e2e
  testing and example usage

### Testing

* Unit
```
go test -v -cover .
=== RUN   TestRunFunction
=== RUN   TestRunFunction/ShouldUpdateContexField
=== RUN   TestRunFunction/ShouldUpdateEnvironmentContexField
=== RUN   TestRunFunction/CanGetQueryFromContext
=== RUN   TestRunFunction/CanGetQueryFromEnvironmentContextKey
=== RUN   TestRunFunction/ResponseIsReturnedWithOptionalManagementGroups
=== RUN   TestRunFunction/ShouldUpdateXRStatus
=== RUN   TestRunFunction/ShouldKeepOtherFieldsInXRStatusDuringUpdate
=== RUN   TestRunFunction/ShouldUpdateNestedContexField
=== RUN   TestRunFunction/CanGetQueryFromNestedContextKey
=== RUN   TestRunFunction/ResponseIsReturned
=== RUN   TestRunFunction/ShouldUpdateNestedComplexFieldinXRStatus
=== RUN   TestRunFunction/CanGetQueryFromXRStatusKey
=== RUN   TestRunFunction/CanGetQueryFromNestedXRStatusKey
=== RUN   TestRunFunction/WarningIfQueryIsEmpty
=== RUN   TestRunFunction/ShouldUpdateNestedFieldinXRStatus
=== RUN   TestRunFunction/ShouldFailWithUnsupportedTarget
--- PASS: TestRunFunction (0.01s)
    --- PASS: TestRunFunction/ShouldUpdateContexField (0.00s)
    --- PASS: TestRunFunction/ShouldUpdateEnvironmentContexField (0.00s)
    --- PASS: TestRunFunction/CanGetQueryFromContext (0.00s)
    --- PASS: TestRunFunction/CanGetQueryFromEnvironmentContextKey (0.00s)
    --- PASS: TestRunFunction/ResponseIsReturnedWithOptionalManagementGroups (0.00s)
    --- PASS: TestRunFunction/ShouldUpdateXRStatus (0.00s)
    --- PASS: TestRunFunction/ShouldKeepOtherFieldsInXRStatusDuringUpdate (0.00s)
    --- PASS: TestRunFunction/ShouldUpdateNestedContexField (0.00s)
    --- PASS: TestRunFunction/CanGetQueryFromNestedContextKey (0.00s)
    --- PASS: TestRunFunction/ResponseIsReturned (0.00s)
    --- PASS: TestRunFunction/ShouldUpdateNestedComplexFieldinXRStatus (0.00s)
    --- PASS: TestRunFunction/CanGetQueryFromXRStatusKey (0.00s)
    --- PASS: TestRunFunction/CanGetQueryFromNestedXRStatusKey (0.00s)
    --- PASS: TestRunFunction/WarningIfQueryIsEmpty (0.00s)
    --- PASS: TestRunFunction/ShouldUpdateNestedFieldinXRStatus (0.00s)
    --- PASS: TestRunFunction/ShouldFailWithUnsupportedTarget (0.00s)
PASS
coverage: 63.9% of statements
ok  	github.com/upbound/function-azresourcegraph	(cached)	coverage: 63.9% of statements
```

* Integration

```
cd example/queryref-from-xr-status
make
crossplane render ./xr.yaml composition.yaml ./functions.yaml --function-credentials=../secrets/azure-creds.yaml  -rc
---
apiVersion: example.crossplane.io/v1
kind: XR
metadata:
  name: example-xr
status:
  azResourceGraphQuery: Resources| count
  azResourceGraphQueryResult:
  - Count: 155
  conditions:
  - lastTransitionTime: "2024-01-01T00:00:00Z"
    reason: Available
    status: "True"
    type: Ready
---
apiVersion: render.crossplane.io/v1beta1
kind: Result
message: 'Query: "Resources| count"'
severity: SEVERITY_NORMAL
step: query-azresourcegraph
---
apiVersion: render.crossplane.io/v1beta1
fields: null
kind: Context
```

* e2e
```
k apply -f example/queryref-from-xr-status/functions.yaml
k apply -f example/queryref-from-xr-status/definition.yaml
k apply -f example/queryref-from-xr-status/composition.yaml
k apply -f example/queryref-from-xr-status/xr.yaml

k get -f example/queryref-from-xr-status/xr.yaml -o yaml
apiVersion: example.crossplane.io/v1
kind: XR
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"example.crossplane.io/v1","kind":"XR","metadata":{"annotations":{},"name":"example-xr"},"spec":{"queryResourceType":"microsoft.compute/virtualmachines"},"status":{"azResourceGraphQuery":"Resources| count"}}
  creationTimestamp: "2025-01-14T10:59:46Z"
  finalizers:
  - composite.apiextensions.crossplane.io
  generation: 4
  labels:
    crossplane.io/composite: example-xr
  name: example-xr
  resourceVersion: "256618"
  uid: d43f13b5-4cbe-4c6c-b17f-7dfd45b466e5
spec:
  compositionRef:
    name: function-azresourcegraph
  compositionRevisionRef:
    name: function-azresourcegraph-8314c09
  compositionUpdatePolicy: Automatic
  queryResourceType: microsoft.compute/virtualmachines
  resourceRefs: []
status:
  azResourceGraphQuery: Resources | where type == "microsoft.compute/virtualmachines"
    | count # < -- Correct query construction
  azResourceGraphQueryResult:
  - Count: 5 < -- Expected result
  claimConditionTypes:
  - FunctionSuccess
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
