### PR TITLE
Resource import example

### DIFF
--- a/example/resource-import/Makefile
+++ b/example/resource-import/Makefile
@@ -1,0 +1,3 @@
+.PHONY: render
+render:
+	crossplane render ../xr.yaml composition.yaml ./functions.yaml --function-credentials=../secrets/azure-creds.yaml  -rc

--- a/example/resource-import/composition.yaml
+++ b/example/resource-import/composition.yaml
@@ -35,10 +35,11 @@ spec:
         kind: KCLInput
         spec:
           source: |
-            queryResult = option("params").ctx.azResourceGraphQueryResult[0]
-            importName = queryResult.name
-            importRgName = queryResult.resourceGroup
-            importLocation = queryResult.location
+            queryResult = option("params").ctx.azResourceGraphQueryResult
+            assert len(queryResult) > 0, "Azure Resource Graph query returned no results. Verify the query criteria."
+            importName = queryResult[0].name
+            importRgName = queryResult[0].resourceGroup
+            importLocation = queryResult[0].location
 
             network = {
               apiVersion = "network.azure.upbound.io/v1beta2"

--- a/example/resource-import/composition.yaml
+++ b/example/resource-import/composition.yaml
@@ -1,0 +1,60 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: function-azresourcegraph
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+    - step: query-azresourcegraph
+      functionRef:
+        name: function-azresourcegraph
+      input:
+        apiVersion: azresourcegraph.fn.crossplane.io/v1alpha1
+        kind: Input
+        query: |
+               Resources
+               | where type == "microsoft.network/virtualnetworks"
+               | where tags["import"] == "me"
+               | project name, resourceGroup, location
+        target: "context.azResourceGraphQueryResult"
+      credentials:
+        - name: azure-creds
+          source: Secret
+          secretRef:
+            namespace: upbound-system
+            name: azure-account-creds
+
+    - step: import-as-observe-only
+      functionRef:
+        name: function-kcl
+      input:
+        apiVersion: krm.kcl.dev/v1alpha1
+        kind: KCLInput
+        spec:
+          source: |
+            queryResult = option("params").ctx.azResourceGraphQueryResult[0]
+            importName = queryResult.name
+            importRgName = queryResult.resourceGroup
+            importLocation = queryResult.location
+
+            network = {
+              apiVersion = "network.azure.upbound.io/v1beta2"
+              kind = "VirtualNetwork"
+              metadata.annotations = {
+                "crossplane.io/external-name" = importName
+              }
+              metadata.name = importName
+              spec.managementPolicies = ["Observe"]
+              spec.forProvider = {
+                resourceGroupName = importRgName
+                location = importLocation
+              }
+            }
+            items = [network]
+
+    - step: automatically-detect-ready-composed-resources
+      functionRef:
+        name: function-auto-ready

--- a/example/resource-import/definition.yaml
+++ b/example/resource-import/definition.yaml
@@ -1,0 +1,43 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xrs.example.crossplane.io
+spec:
+  group: example.crossplane.io
+  names:
+    categories:
+    - crossplane
+    kind: XR
+    plural: xrs
+  versions:
+  - name: v1
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        description: XR is the Schema for the XR API.
+        properties:
+          spec:
+            description: XRSpec defines the desired state of XR.
+            type: object
+          status:
+            description: XRStatus defines the observed state of XR.
+            type: object
+            properties:
+              azResourceGraphQueryResult:
+                description: Freeform field containing query results from function-azresourcegraph
+                type: array
+                items:
+                  type: object
+                x-kubernetes-preserve-unknown-fields: true
+        required:
+        - spec
+        type: object
+    served: true
+status:
+  controllers:
+    compositeResourceClaimType:
+      apiVersion: ""
+      kind: ""
+    compositeResourceType:
+      apiVersion: ""
+      kind: ""

--- a/example/resource-import/functions.yaml
+++ b/example/resource-import/functions.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-azresourcegraph
+  annotations:
+    # This tells crossplane beta render to connect to the function locally.
+    #render.crossplane.io/runtime: Development
+spec:
+  package: xpkg.upbound.io/upbound/function-azresourcegraph:v0.4.0
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-kcl
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-kcl:v0.11.0
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-auto-ready
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.4.0


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

* Get the data from az resource graph

* Drive the import with function-kcl

### Tests

* Render
```
 make
crossplane render ../xr.yaml composition.yaml ./functions.yaml --function-credentials=../secrets/azure-creds.yaml  -rc
---
apiVersion: example.crossplane.io/v1
kind: XR
metadata:
  name: example-xr
status:
  conditions:
  - lastTransitionTime: "2024-01-01T00:00:00Z"
    message: 'Unready resources: platform-ref-azure-vnet'
    reason: Creating
    status: "False"
    type: Ready
---
apiVersion: network.azure.upbound.io/v1beta2
kind: VirtualNetwork
metadata:
  annotations:
    crossplane.io/composition-resource-name: platform-ref-azure-vnet
    crossplane.io/external-name: platform-ref-azure-vnet
  generateName: example-xr-
  labels:
    crossplane.io/composite: example-xr
  name: platform-ref-azure-vnet
  ownerReferences:
  - apiVersion: example.crossplane.io/v1
    blockOwnerDeletion: true
    controller: true
    kind: XR
    name: example-xr
    uid: ""
spec:
  forProvider:
    location: westus
    resourceGroupName: platform-ref-azure-4b29m-2jvwc
  managementPolicies:
  - Observe
---
apiVersion: render.crossplane.io/v1beta1
kind: Result
message: 'Query: "Resources\n| where type == \"microsoft.network/virtualnetworks\"\n|
  where tags[\"import\"] == \"me\"\n| project name, resourceGroup, location\n"'
severity: SEVERITY_NORMAL
step: query-azresourcegraph
---
apiVersion: render.crossplane.io/v1beta1
fields:
  azResourceGraphQueryResult:
  - location: westus
    name: platform-ref-azure-vnet
    resourceGroup: platform-ref-azure-4b29m-2jvwc
kind: Context
```

* e2e

```
k apply -f example/resource-import/
k apply -f example/xr.yaml
...
 crossplane beta trace xrs example-xr
NAME                                        SYNCED   READY   STATUS
XR/example-xr                               True     True    Available
└─ VirtualNetwork/platform-ref-azure-vnet   True     True    Available

k get VirtualNetwork/platform-ref-azure-vnet -o yaml
apiVersion: network.azure.upbound.io/v1beta2
kind: VirtualNetwork
metadata:
  annotations:
    crossplane.io/composition-resource-name: platform-ref-azure-vnet
    crossplane.io/external-name: platform-ref-azure-vnet
  creationTimestamp: "2025-01-15T16:21:29Z"
  finalizers:
  - finalizer.managedresource.crossplane.io
  generateName: example-xr-
  generation: 1
  labels:
    crossplane.io/claim-name: ""
    crossplane.io/claim-namespace: ""
    crossplane.io/composite: example-xr
  name: platform-ref-azure-vnet
  ownerReferences:
  - apiVersion: example.crossplane.io/v1
    blockOwnerDeletion: true
    controller: true
    kind: XR
    name: example-xr
    uid: 1a71938f-3a05-4d6c-b344-0d68272cc820
  resourceVersion: "12794"
  uid: 5772317e-12da-4ac0-8202-cf718bee7322
spec:
  deletionPolicy: Delete
  forProvider:
    location: westus
    resourceGroupName: platform-ref-azure-4b29m-2jvwc
  initProvider: {}
  managementPolicies:
  - Observe
  providerConfigRef:
    name: default
status:
  atProvider:
    addressSpace:
    - 192.168.0.0/16
    bgpCommunity: ""
    edgeZone: ""
    flowTimeoutInMinutes: 0
    guid: a850a2bd-ffc2-47b1-aa1d-2f9aaf897f33
    id: /subscriptions/<redacted>/resourceGroups/platform-ref-azure-4b29m-2jvwc/providers/Microsoft.Network/virtualNetworks/platform-ref-azure-vnet
    location: westus
    resourceGroupName: platform-ref-azure-4b29m-2jvwc
    subnet:
    - addressPrefix: 192.168.1.0/24
      id: /subscriptions/<redacted>/resourceGroups/platform-ref-azure-4b29m-2jvwc/providers/Microsoft.Network/virtualNetworks/platform-ref-azure-vnet/subnets/platform-ref-azure-sn
      name: platform-ref-azure-sn
      securityGroup: ""
    tags:
      import: me
  conditions:
  - lastTransitionTime: "2025-01-15T16:21:31Z"
    reason: ReconcileSuccess
    status: "True"
    type: Synced
  - lastTransitionTime: "2025-01-15T16:31:46Z"
    reason: Available
    status: "True"
    type: Ready
```
Note: Observe only resource readiness depends on provider poll-interval (default 10m)
So you might encounter a readiness waiting situation similar to the one below
```
$ k get managed
NAME                                                              SYNCED   READY   EXTERNAL-NAME             AGE
virtualnetwork.network.azure.upbound.io/platform-ref-azure-vnet   True             platform-ref-azure-vnet   8m37s
$ k get managed
NAME                                                              SYNCED   READY   EXTERNAL-NAME             AGE
virtualnetwork.network.azure.upbound.io/platform-ref-azure-vnet   True     True    platform-ref-azure-vnet   10m
```


I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
