### PR TITLE
Use v1beta1 for MR in import example

### DIFF
--- a/example/resource-import/composition.yaml
+++ b/example/resource-import/composition.yaml
@@ -42,7 +42,7 @@ spec:
             importLocation = queryResult[0].location
 
             network = {
-              apiVersion = "network.azure.upbound.io/v1beta2"
+              apiVersion = "network.azure.upbound.io/v1beta1"
               kind = "VirtualNetwork"
               metadata.annotations = {
                 "crossplane.io/external-name" = importName


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Avoid https://github.com/crossplane/upjet/issues/460

After the change the import is happening within seconds instead of 10 minutes
```
k get composite
NAME         SYNCED   READY   COMPOSITION                AGE
example-xr   True     True    function-azresourcegraph   14s
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
