### PR TITLE
Fix case for multiple step queries publishing to multiple XR fields

### DIFF
--- a/example/multiple-queries-to-multiple-xr-fields/Makefile
+++ b/example/multiple-queries-to-multiple-xr-fields/Makefile
@@ -1,0 +1,3 @@
+.PHONY: render
+render:
+	crossplane render ./xr.yaml composition.yaml ../functions.yaml --function-credentials=../secrets/azure-creds.yaml  -rc

--- a/example/multiple-queries-to-multiple-xr-fields/composition.yaml
+++ b/example/multiple-queries-to-multiple-xr-fields/composition.yaml
@@ -1,0 +1,38 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: function-azresourcegraph
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+  - step: query-azresourcegraph1
+    functionRef:
+      name: function-azresourcegraph
+    input:
+      apiVersion: azresourcegraph.fn.crossplane.io/v1alpha1
+      kind: Input
+      query: "Resources | project name, location, type, id| where type =~ 'Microsoft.Compute/virtualMachines' | count"
+      target: "status.azResourceGraphQueryResult1"
+    credentials:
+      - name: azure-creds
+        source: Secret
+        secretRef:
+          namespace: upbound-system
+          name: azure-account-creds
+  - step: query-azresourcegraph2
+    functionRef:
+      name: function-azresourcegraph
+    input:
+      apiVersion: azresourcegraph.fn.crossplane.io/v1alpha1
+      kind: Input
+      query: "Resources | project name, location, type, id| where type =~ 'Microsoft.Compute/virtualMachines' | count"
+      target: "status.azResourceGraphQueryResult2"
+    credentials:
+      - name: azure-creds
+        source: Secret
+        secretRef:
+          namespace: upbound-system
+          name: azure-account-creds

--- a/example/multiple-queries-to-multiple-xr-fields/definition.yaml
+++ b/example/multiple-queries-to-multiple-xr-fields/definition.yaml
@@ -1,0 +1,49 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xrs.example.crossplane.io
+spec:
+  group: example.crossplane.io
+  names:
+    categories:
+    - crossplane
+    kind: XR
+    plural: xrs
+  versions:
+  - name: v1
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        description: XR is the Schema for the XR API.
+        properties:
+          spec:
+            description: XRSpec defines the desired state of XR.
+            type: object
+          status:
+            description: XRStatus defines the observed state of XR.
+            type: object
+            properties:
+              azResourceGraphQueryResult1:
+                description: Freeform field containing query results from function-azresourcegraph
+                type: array
+                items:
+                  type: object
+                x-kubernetes-preserve-unknown-fields: true
+              azResourceGraphQueryResult2:
+                description: Freeform field containing query results from function-azresourcegraph
+                type: array
+                items:
+                  type: object
+                x-kubernetes-preserve-unknown-fields: true
+        required:
+        - spec
+        type: object
+    served: true
+status:
+  controllers:
+    compositeResourceClaimType:
+      apiVersion: ""
+      kind: ""
+    compositeResourceType:
+      apiVersion: ""
+      kind: ""

--- a/example/multiple-queries-to-multiple-xr-fields/xr.yaml
+++ b/example/multiple-queries-to-multiple-xr-fields/xr.yaml
@@ -1,0 +1,6 @@
+# Replace this with your XR!
+apiVersion: example.crossplane.io/v1
+kind: XR
+metadata:
+  name: example-xr
+spec: {}

--- a/fn_test.go
+++ b/fn_test.go
@@ -355,6 +355,84 @@ func TestRunFunction(t *testing.T) {
 				},
 			},
 		},
+		"ShouldKeepOtherFieldsFromPreviousPipelineStepInXRStatusDuringUpdate": {
+			reason: "The Function should update nested field in XR status and keep the other status fields intact if they are coming from previous pipeline step",
+			args: args{
+				ctx: context.Background(),
+				req: &fnv1.RunFunctionRequest{
+					Meta: &fnv1.RequestMeta{Tag: "hello"},
+					Input: resource.MustStructJSON(`{
+						"apiVersion": "azresourcegraph.fn.crossplane.io/v1alpha1",
+						"kind": "Input",
+						"query": "Resources| count",
+						"managementGroups": ["test"],
+						"target": "status.nestedField.azResourceGraphQueryResult"
+					}`),
+					Observed: &fnv1.State{
+						Composite: &fnv1.Resource{
+							Resource: resource.MustStructJSON(`{
+								"apiVersion": "example.org/v1",
+								"kind": "XR",
+								"status": {
+									"someFieldObserved": "keepmearound"
+								}}`),
+						},
+					},
+					Desired: &fnv1.State{
+						Composite: &fnv1.Resource{
+							Resource: resource.MustStructJSON(`{
+								"apiVersion": "example.org/v1",
+								"kind": "XR",
+								"status": {
+									"someFieldDesired": "keepmearound"
+								}}`),
+						},
+					},
+					Credentials: map[string]*fnv1.Credentials{
+						"azure-creds": {
+							Source: &fnv1.Credentials_CredentialData{CredentialData: creds},
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: &fnv1.RunFunctionResponse{
+					Meta: &fnv1.ResponseMeta{Tag: "hello", Ttl: durationpb.New(response.DefaultTTL)},
+					Conditions: []*fnv1.Condition{
+						{
+							Type:   "FunctionSuccess",
+							Status: fnv1.Status_STATUS_CONDITION_TRUE,
+							Reason: "Success",
+							Target: fnv1.Target_TARGET_COMPOSITE_AND_CLAIM.Enum(),
+						},
+					},
+					Results: []*fnv1.Result{
+						{
+							Severity: fnv1.Severity_SEVERITY_NORMAL,
+							Message:  `Query: "Resources| count"`,
+							Target:   fnv1.Target_TARGET_COMPOSITE.Enum(),
+						},
+					},
+					Desired: &fnv1.State{
+						Composite: &fnv1.Resource{
+							Resource: resource.MustStructJSON(`{
+								"apiVersion": "example.org/v1",
+								"kind": "XR",
+								"status": {
+									"someFieldObserved": "keepmearound",
+									"someFieldDesired": "keepmearound",
+									"nestedField": {
+										"azResourceGraphQueryResult":
+											{
+												"resource": "mock-resource"
+											}
+									}
+								}}`),
+						},
+					},
+				},
+			},
+		},
 		"ShouldFailWithUnsupportedTarget": {
 			reason: "The Function fail in case of unsupported value in Target Field",
 			args: args{

--- a/fn_test.go
+++ b/fn_test.go
@@ -368,16 +368,6 @@ func TestRunFunction(t *testing.T) {
 						"managementGroups": ["test"],
 						"target": "status.nestedField.azResourceGraphQueryResult"
 					}`),
-					Observed: &fnv1.State{
-						Composite: &fnv1.Resource{
-							Resource: resource.MustStructJSON(`{
-								"apiVersion": "example.org/v1",
-								"kind": "XR",
-								"status": {
-									"someFieldObserved": "keepmearound"
-								}}`),
-						},
-					},
 					Desired: &fnv1.State{
 						Composite: &fnv1.Resource{
 							Resource: resource.MustStructJSON(`{
@@ -419,7 +409,6 @@ func TestRunFunction(t *testing.T) {
 								"apiVersion": "example.org/v1",
 								"kind": "XR",
 								"status": {
-									"someFieldObserved": "keepmearound",
 									"someFieldDesired": "keepmearound",
 									"nestedField": {
 										"azResourceGraphQueryResult":


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This PR fixes the situation when we have multiple queries as multiple pipeline steps and not including the results from the previous step into XR status.

See included example.

Before:
```
crossplane render ./xr.yaml composition.yaml ../functions.yaml --function-credentials=../secrets/azure-creds.yaml  -rc
---
apiVersion: example.crossplane.io/v1
kind: XR
metadata:
  name: example-xr
status:
  azResourceGraphQueryResult2:
  - Count: 5
  conditions:
  - lastTransitionTime: "2024-01-01T00:00:00Z"
    reason: Available
    status: "True"
    type: Ready
```

After:
```
crossplane render ./xr.yaml composition.yaml ../functions.yaml --function-credentials=../secrets/azure-creds.yaml  -rc
---
apiVersion: example.crossplane.io/v1
kind: XR
metadata:
  name: example-xr
status:
  azResourceGraphQueryResult1:
  - Count: 5
  azResourceGraphQueryResult2:
  - Count: 5
  conditions:
  - lastTransitionTime: "2024-01-01T00:00:00Z"
    reason: Available
    status: "True"
    type: Ready
---
```

# Testing

* Unit
```
go test -v -cover .
=== RUN   TestRunFunction
=== RUN   TestRunFunction/ResponseIsReturned
=== RUN   TestRunFunction/ShouldUpdateNestedContexField
=== RUN   TestRunFunction/CanGetQueryFromNestedXRStatusKey
=== RUN   TestRunFunction/ShouldUpdateNestedComplexFieldinXRStatus
=== RUN   TestRunFunction/ShouldKeepOtherFieldsFromPreviousPipelineStepInXRStatusDuringUpdate
=== RUN   TestRunFunction/ShouldUpdateContexField
=== RUN   TestRunFunction/CanGetQueryFromContext
=== RUN   TestRunFunction/CanGetQueryFromEnvironmentContextKey
=== RUN   TestRunFunction/CanGetQueryFromXRStatusKey
=== RUN   TestRunFunction/ResponseIsReturnedWithOptionalManagementGroups
=== RUN   TestRunFunction/ShouldUpdateXRStatus
=== RUN   TestRunFunction/ShouldKeepOtherFieldsInXRStatusDuringUpdate
=== RUN   TestRunFunction/ShouldFailWithUnsupportedTarget
=== RUN   TestRunFunction/ShouldUpdateEnvironmentContexField
=== RUN   TestRunFunction/ShouldUpdateNestedFieldinXRStatus
=== RUN   TestRunFunction/CanGetQueryFromNestedContextKey
=== RUN   TestRunFunction/WarningIfQueryIsEmpty
--- PASS: TestRunFunction (0.01s)
    --- PASS: TestRunFunction/ResponseIsReturned (0.00s)
    --- PASS: TestRunFunction/ShouldUpdateNestedContexField (0.00s)
    --- PASS: TestRunFunction/CanGetQueryFromNestedXRStatusKey (0.00s)
    --- PASS: TestRunFunction/ShouldUpdateNestedComplexFieldinXRStatus (0.00s)
    --- PASS: TestRunFunction/ShouldKeepOtherFieldsFromPreviousPipelineStepInXRStatusDuringUpdate (0.00s)
    --- PASS: TestRunFunction/ShouldUpdateContexField (0.00s)
    --- PASS: TestRunFunction/CanGetQueryFromContext (0.00s)
    --- PASS: TestRunFunction/CanGetQueryFromEnvironmentContextKey (0.00s)
    --- PASS: TestRunFunction/CanGetQueryFromXRStatusKey (0.00s)
    --- PASS: TestRunFunction/ResponseIsReturnedWithOptionalManagementGroups (0.00s)
    --- PASS: TestRunFunction/ShouldUpdateXRStatus (0.00s)
    --- PASS: TestRunFunction/ShouldKeepOtherFieldsInXRStatusDuringUpdate (0.00s)
    --- PASS: TestRunFunction/ShouldFailWithUnsupportedTarget (0.00s)
    --- PASS: TestRunFunction/ShouldUpdateEnvironmentContexField (0.00s)
    --- PASS: TestRunFunction/ShouldUpdateNestedFieldinXRStatus (0.00s)
    --- PASS: TestRunFunction/CanGetQueryFromNestedContextKey (0.00s)
    --- PASS: TestRunFunction/WarningIfQueryIsEmpty (0.00s)
PASS
coverage: 64.2% of statements
ok  	github.com/upbound/function-azresourcegraph	(cached)	coverage: 64.2% of statements
```

* Integration
```
 make
crossplane render ./xr.yaml composition.yaml ../functions.yaml --function-credentials=../secrets/azure-creds.yaml  -rc
---
apiVersion: example.crossplane.io/v1
kind: XR
metadata:
  name: example-xr
status:
  azResourceGraphQueryResult1:
  - Count: 5
  azResourceGraphQueryResult2:
  - Count: 5
  conditions:
  - lastTransitionTime: "2024-01-01T00:00:00Z"
    reason: Available
    status: "True"
    type: Ready
  observerdField: keepmearound
---
apiVersion: render.crossplane.io/v1beta1
kind: Result
message: 'Query: "Resources | project name, location, type, id| where type =~ ''Microsoft.Compute/virtualMachines''
  | count"'
severity: SEVERITY_NORMAL
step: query-azresourcegraph1
---
apiVersion: render.crossplane.io/v1beta1
kind: Result
message: 'Query: "Resources | project name, location, type, id| where type =~ ''Microsoft.Compute/virtualMachines''
  | count"'
severity: SEVERITY_NORMAL
step: query-azresourcegraph2
---
apiVersion: render.crossplane.io/v1beta1
fields: null
kind: Context
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
