### PR TITLE
Add implementation for custom Subscriptions input

### DIFF
--- a/example/query-with-multiple-subscriptions/Makefile
+++ b/example/query-with-multiple-subscriptions/Makefile
@@ -1,0 +1,3 @@
+.PHONY: render
+render:
+	crossplane render ../xr.yaml composition.yaml ../functions.yaml --function-credentials=../secrets/azure-creds.yaml  -rc

--- a/example/query-with-multiple-subscriptions/composition.yaml
+++ b/example/query-with-multiple-subscriptions/composition.yaml
@@ -1,0 +1,27 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: function-azresourcegraph
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+  - step: query-azresourcegraph
+    functionRef:
+      name: function-azresourcegraph
+    input:
+      apiVersion: azresourcegraph.fn.crossplane.io/v1alpha1
+      kind: Input
+      query: "Resources | project name, location, type, id| where type =~ 'Microsoft.Compute/virtualMachines' | order by name desc"
+      subscriptions:
+        - 00000000-0000-0000-0000-000000000001
+        - 00000000-0000-0000-0000-000000000002
+      target: "status.azResourceGraphQueryResult"
+    credentials:
+      - name: azure-creds
+        source: Secret
+        secretRef:
+          namespace: upbound-system
+          name: azure-account-creds

--- a/example/query-with-multiple-subscriptions/definition.yaml
+++ b/example/query-with-multiple-subscriptions/definition.yaml
@@ -1,0 +1,43 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xrs.example.crossplane.io
+spec:
+  group: example.crossplane.io
+  names:
+    categories:
+    - crossplane
+    kind: XR
+    plural: xrs
+  versions:
+  - name: v1
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        description: XR is the Schema for the XR API.
+        properties:
+          spec:
+            description: XRSpec defines the desired state of XR.
+            type: object
+          status:
+            description: XRStatus defines the observed state of XR.
+            type: object
+            properties:
+              azResourceGraphQueryResult:
+                description: Freeform field containing query results from function-azresourcegraph
+                type: array
+                items:
+                  type: object
+                x-kubernetes-preserve-unknown-fields: true
+        required:
+        - spec
+        type: object
+    served: true
+status:
+  controllers:
+    compositeResourceClaimType:
+      apiVersion: ""
+      kind: ""
+    compositeResourceType:
+      apiVersion: ""
+      kind: ""

--- a/fn.go
+++ b/fn.go
@@ -283,6 +283,7 @@ func getCreds(req *fnv1.RunFunctionRequest) (map[string]string, error) {
 // that interacts with Azure Resource Graph API.
 type AzureQuery struct{}
 
+// azQuery is a concrete implementation that interacts with Azure Resource Graph API.
 func (a *AzureQuery) azQuery(ctx context.Context, azureCreds map[string]string, in *v1beta1.Input) (armresourcegraph.ClientResourcesResponse, error) {
 	tenantID := azureCreds["tenantId"]
 	clientID := azureCreds["clientId"]
@@ -307,7 +308,12 @@ func (a *AzureQuery) azQuery(ctx context.Context, azureCreds map[string]string, 
 		Query: to.Ptr(in.Query),
 	}
 
-	if len(subscriptionID) > 0 {
+	// Handle subscriptions in the following priority:
+	// 1. Use Subscriptions field from Input if provided
+	// 2. Otherwise use the subscriptionID from creds if available
+	if len(in.Subscriptions) > 0 {
+		queryRequest.Subscriptions = in.Subscriptions
+	} else if len(subscriptionID) > 0 {
 		queryRequest.Subscriptions = []*string{to.Ptr(subscriptionID)}
 	}
 

--- a/input/v1beta1/input.go
+++ b/input/v1beta1/input.go
@@ -35,6 +35,10 @@ type Input struct {
 	// +optional
 	ManagementGroups []*string `json:"managementGroups,omitempty"`
 
+	// Azure subscriptions against which to execute the query. Example: [ 'sub1','sub2' ]
+	// +optional
+	Subscriptions []*string `json:"subscriptions,omitempty"`
+
 	// Target where to store the Query Result
 	Target string `json:"target"`
 

--- a/input/v1beta1/zz_generated.deepcopy.go
+++ b/input/v1beta1/zz_generated.deepcopy.go
@@ -29,6 +29,17 @@ func (in *Input) DeepCopyInto(out *Input) {
 			}
 		}
 	}
+	if in.Subscriptions != nil {
+		in, out := &in.Subscriptions, &out.Subscriptions
+		*out = make([]*string, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(string)
+				**out = **in
+			}
+		}
+	}
 	if in.SkipQueryWhenTargetHasData != nil {
 		in, out := &in.SkipQueryWhenTargetHasData, &out.SkipQueryWhenTargetHasData
 		*out = new(bool)

--- a/package/input/azresourcegraph.fn.crossplane.io_inputs.yaml
+++ b/package/input/azresourcegraph.fn.crossplane.io_inputs.yaml
@@ -57,6 +57,12 @@ spec:
               SkipQueryWhenTargetHasData controls whether to skip the query when the target already has data
               Default is false to ensure continuous reconciliation
             type: boolean
+          subscriptions:
+            description: 'Azure subscriptions against which to execute the query.
+              Example: [ ''sub1'',''sub2'' ]'
+            items:
+              type: string
+            type: array
           target:
             description: Target where to store the Query Result
             type: string


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Ability to explicitly specify Subscriptions in Input spec instead of purely relying on the credentials.

Credentials-based propagation is still there for complete backward compatibility.


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
