### PR TITLE
Add round-robin service principal authentication to mitigate Azure ResourceGraph throttling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
- # function-azresourcegraph
+# function-azresourcegraph
 [![CI](https://github.com/upbound/function-azresourcegraph/actions/workflows/ci.yml/badge.svg)](https://github.com/upbound/function-azresourcegraph/actions/workflows/ci.yml)
 
 A function to query [Azure Resource Graph][azresourcegraph]

--- a/fn_test.go
+++ b/fn_test.go
@@ -21,10 +21,10 @@ import (
 )
 
 type MockAzureQuery struct {
-	AzQueryFunc func(ctx context.Context, azureCreds []map[string]string, in *v1beta1.Input, log logging.Logger) (armresourcegraph.ClientResourcesResponse, error)
+	AzQueryFunc func(ctx context.Context, azureCreds interface{}, in *v1beta1.Input, log logging.Logger) (armresourcegraph.ClientResourcesResponse, error)
 }
 
-func (m *MockAzureQuery) azQuery(ctx context.Context, azureCreds []map[string]string, in *v1beta1.Input, log logging.Logger) (armresourcegraph.ClientResourcesResponse, error) {
+func (m *MockAzureQuery) azQuery(ctx context.Context, azureCreds interface{}, in *v1beta1.Input, log logging.Logger) (armresourcegraph.ClientResourcesResponse, error) {
 	return m.AzQueryFunc(ctx, azureCreds, in, log)
 }
 
@@ -2754,7 +2754,7 @@ func TestRunFunction(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			// Mocking the azQuery function to return a successful result
 			mockQuery := &MockAzureQuery{
-				AzQueryFunc: func(_ context.Context, _ []map[string]string, _ *v1beta1.Input, _ logging.Logger) (armresourcegraph.ClientResourcesResponse, error) {
+				AzQueryFunc: func(_ context.Context, _ interface{}, _ *v1beta1.Input, _ logging.Logger) (armresourcegraph.ClientResourcesResponse, error) {
 					return armresourcegraph.ClientResourcesResponse{
 						QueryResponse: armresourcegraph.QueryResponse{
 							Count:           to.Ptr(int64(1)),

--- a/fn_test.go
+++ b/fn_test.go
@@ -21,11 +21,11 @@ import (
 )
 
 type MockAzureQuery struct {
-	AzQueryFunc func(ctx context.Context, azureCreds map[string]string, in *v1beta1.Input) (armresourcegraph.ClientResourcesResponse, error)
+	AzQueryFunc func(ctx context.Context, azureCreds []map[string]string, in *v1beta1.Input, log logging.Logger) (armresourcegraph.ClientResourcesResponse, error)
 }
 
-func (m *MockAzureQuery) azQuery(ctx context.Context, azureCreds map[string]string, in *v1beta1.Input) (armresourcegraph.ClientResourcesResponse, error) {
-	return m.AzQueryFunc(ctx, azureCreds, in)
+func (m *MockAzureQuery) azQuery(ctx context.Context, azureCreds []map[string]string, in *v1beta1.Input, log logging.Logger) (armresourcegraph.ClientResourcesResponse, error) {
+	return m.AzQueryFunc(ctx, azureCreds, in, log)
 }
 
 func strPtr(s string) *string {
@@ -2754,7 +2754,7 @@ func TestRunFunction(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			// Mocking the azQuery function to return a successful result
 			mockQuery := &MockAzureQuery{
-				AzQueryFunc: func(_ context.Context, _ map[string]string, _ *v1beta1.Input) (armresourcegraph.ClientResourcesResponse, error) {
+				AzQueryFunc: func(_ context.Context, _ []map[string]string, _ *v1beta1.Input, _ logging.Logger) (armresourcegraph.ClientResourcesResponse, error) {
 					return armresourcegraph.ClientResourcesResponse{
 						QueryResponse: armresourcegraph.QueryResponse{
 							Count:           to.Ptr(int64(1)),


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This PR implements round-robin service principal authentication for Azure Resource Graph function to help distribute load and avoid Azure throttling when using multiple service principals.

Similar functionality has been added to the Azure provider (see [provider-upjet-azure#1027](https://github.com/crossplane-contrib/provider-upjet-azure/pull/1027)) and this implementation follows the same pattern.

**Key Changes:**
- Added support for multiple service principals in JSON array format in credentials secret
- Implemented atomic counter-based round-robin selection for service principal rotation
- Old way is also supported - no changes needed there

**How Round-Robin Works:**
- Each reconciliation cycle uses the next service principal in sequence
- Automatically distributes load across multiple service principals
- Reduces likelihood of Azure API throttling (HTTP 429)

**Supported Credential Formats:**
```json
// Single Service Principal (existing)
{
    "subscriptionId": "sub-id",
    "tenantId": "tenant-id", 
    "clientId": "client-1",
    "clientSecret": "secret-1"
}

// Multiple Service Principals (new)
[
    {
        "subscriptionId": "sub-id",
        "tenantId": "tenant-id",
        "clientId": "client-1", 
        "clientSecret": "secret-1"
    },
    {
        "subscriptionId": "sub-id",
        "tenantId": "tenant-id",
        "clientId": "client-2",
        "clientSecret": "secret-2"
    }
]
```

**Benefits:**
- Prevents Azure ARM throttling by distributing requests across multiple identities
- Load balancing across service principals for better performance
- Easy to add more service principals without code changes

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute